### PR TITLE
Removed '/fitness' from mongo connection

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose')
 
 const connectDB = async () =>{
     try{
-        const conn = await mongoose.connect(process.env.MONGO_URI,'/fitness',{
+        const conn = await mongoose.connect(process.env.MONGO_URI,{
             useNewUrlParser: true,
             useUnifiedTopology: true,
             useFindAndModify: true


### PR DESCRIPTION
Inputting the intended database name is no longer allowed with mongoose. the database name as to be established in '.env' or config variable on production